### PR TITLE
Removed Babel dependencies and added `child_process.execFile` monkeypatching

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,0 +1,43 @@
+var childProcess = require("child_process")
+  , fs = require("fs")
+  , Path = require("path")
+
+var orig_execFile = childProcess.execFile
+
+childProcess.execFile = function(file, commandArgs) {
+  if (
+    file === "git" &&
+    commandArgs.length > 1 &&
+    commandArgs[0] === "add" &&
+    Path.basename(commandArgs[1]) === "package.json"
+  ) {
+    var orig_args = arguments
+    var args = Array.prototype.slice.apply(orig_args)
+
+    return check_override(module.exports.formats.slice(0))
+
+    function check_override(list) {
+      var err
+      var alt_file = list.shift()
+      args[1][1] = Path.join(Path.dirname(commandArgs[1]), alt_file)
+
+      try {
+        fs.statSync(args[1][1], "utf8")
+      } catch(err) {
+        if (list.length) {
+          return check_override(list)
+        } else {
+          alt_file = module.exports.formats[0]
+          args[1][1] = Path.join(Path.dirname(commandArgs[1]), alt_file)
+
+          /* fallthrough */
+        }
+      }
+
+      // alt_file exists, so assuming that user works with this format
+      return orig_execFile.apply(childProcess, args)
+    }
+  } else {
+    return orig_execFile.apply(childProcess, arguments)
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,3 +15,6 @@ require("./write").formats = formats;
 
 // Overwriting fs.readFile[Sync]
 require("./read").formats = formats;
+
+// Overwriting child_process.exec[Sync]
+require("./exec").formats = formats;

--- a/npm-json5.js
+++ b/npm-json5.js
@@ -1,4 +1,3 @@
 #!/usr/bin/env node
-require("babel-core/register");
 require("./lib")
 require("npm/cli")

--- a/package.json
+++ b/package.json
@@ -35,8 +35,6 @@
     "npm-json5": "./npm-json5.js"
   },
   "dependencies": {
-    "babel-preset-es2015": "^6.6.0",
-    "babel-register": "^6.7.2",
     "jju": "*",
     "npm": "*"
   },


### PR DESCRIPTION
This ensures `npm version` works, perhaps it also fixes other use cases where the `git add package.json` command is run.

Babel wasn't necessary, so I removed it. I maintained the coding style from the other existing files, even though I find it a bit dated and odd.
