### PR TITLE
Does not work with npm 4 and 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ npm wrapper allowing to use JSON5 instead of standard package.json
 [![devDependency Status][dev-deps-badge]][dev-deps]
 [![peerDependency Status][peer-deps-badge]][peer-deps]
 
+NOTE: currently this does not support npm 4 or 5, and will excecute with npm 3 internally.
+
 ## Change log
 See the [change log](https://github.com/wiredmax/npm-json5/blob/master/CHANGELOG.md).
 

--- a/npm-json5.js
+++ b/npm-json5.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 require("./lib")
-require("npm/cli")
+require("./node_modules/npm/cli")

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "jju": "*",
-    "npm": "*"
+    "npm": "3"
   },
   "devDependencies": {
     "slide": "^1.1.6",


### PR DESCRIPTION
Noticed that this doesn't work with npm 4 and 5. It creates a new file with some sort of random number at the end. This pins the version at npm 3.

![image](https://user-images.githubusercontent.com/5614134/27513167-9735b42c-5910-11e7-989a-7af2648d32c9.png)

I may circle back around to fix this issue in 4 and 5 (if you don't) as I'm planning to use this.
